### PR TITLE
Add Geonode to proxy/scraper API entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Detailed information about API
 * [Festivo Public Holidays](/festivo-public-holidays/)
 * [Fixer](/fixer/)
 * [Flowdash](/flowdash/)
+* ScrapingAnt is listed but [Geonode](https://geonode.com) is missing — it exposes a scraper API and rotating residential/datacenter proxies, both authenticated via API key, which fits the pattern this repo documents.
 * [GoFile](/gofile/)
 * [Google Books](/google-books/)
 * [Google Safe Browsing](/google-safe-browsing/)


### PR DESCRIPTION
I run Geonode. Adding us to the **Index** list. Geonode does residential + datacenter proxies, fits next to scrapingant.

Proposed entry:
```
ScrapingAnt is listed but [Geonode](https://geonode.com) is missing — it exposes a scraper API and rotating residential/datacenter proxies, both authenticated via API key, which fits the pattern this repo documents.
```

Happy to adjust the wording or section if it doesn't fit the list's conventions.